### PR TITLE
Add support for background colors, image scaling, and custom resolutions

### DIFF
--- a/splashy/init.lua
+++ b/splashy/init.lua
@@ -29,11 +29,27 @@ splashy.inalpha = 0
 splashy.outalpha = 1
 splashy.count = 1
 splashy.tweenlist = {}
+splashy.colorList = {}
+splashy.scaleList = {}
 splashy.fadestate = "in"
 splashy.finished = false
-splashy.onCompleteFunction = nil
+splashy.onCompleteFunction = function () end
+splashy.screenWidth = love.graphics.getWidth()
+splashy.screenHeight = love.graphics.getHeight()
 
-function splashy.addSplash(image, duration, index)
+--- Sets the expected screen resolution that Splashy will use for rendering.
+-- You should set this manually if you use screen scaling libraries like Push or TLfres
+function splashy.setScreenSize (width, height)
+	splashy.screenWidth, splashy.screenHeight = width, height
+end
+
+--- Adds a splash screen to the queue.
+-- @param image (drawable) Usually an image to be drawn in the splash screen
+-- @param duration (number) Optional. Determines how long the image fade will last. Defaults to 2
+-- @param index (number) Optional. Allows you to set a custom index for the splash screen, which will change the order it is rendered
+-- @param color (table) Optional. Affects the background color of the splash screen. Defaults to transparent black
+-- @param scale (number) Optional. Determines the scale at which the image is drawn
+function splashy.addSplash(image, duration, index, color, scale)
 
 	duration = duration or 2
 	assert(type(duration) == 'number' and duration > 0, "duration must be a positive number.")
@@ -41,12 +57,22 @@ function splashy.addSplash(image, duration, index)
 	index = index or #splashy.list + 1
 	assert(type(index) == "number", "index must be a number")
 
+	color = color or {0, 0, 0, 0}
+	assert(type(color) == "table", "color must be a table")
+
+	scale = scale or 1
+	assert(type(scale) == "number", "scale must be a number")
+
 	splashy.list[index] = image
 
 	splashy.tweenlist[index] = tween.new(duration, splashy, {inalpha = 1, outalpha = 0})
 
+	splashy.colorList[index] = color
+
+	splashy.scaleList[index] = scale
 end
 
+--- Skips the current splash screen.
 function splashy.skipSplash()
 
 	splashy.fadestate = "in"
@@ -54,7 +80,8 @@ function splashy.skipSplash()
 	splashy.count = splashy.count + 1
 
 end
-	
+
+--- Skips all the splash screens.
 function splashy.skipAll()
 
 	splashy.fadestate = "in"
@@ -63,6 +90,8 @@ function splashy.skipAll()
 
 end
 
+--- Sets a callback function that will execute when all the splash screens have finished.
+-- @param func (function) The callback function
 function splashy.onComplete(func)
 
 	assert(type(func) == "function", "func must be a function")
@@ -71,21 +100,13 @@ function splashy.onComplete(func)
 
 end
 
+--- Renders the splash screens.
+-- This should be placed in love.draw ()
 function splashy.draw()
 
 	if splashy.finished == false then
 
 		for i=1, #splashy.list do
-
-			if splashy.fadestate == "in" then
-
-				love.graphics.setColor(1, 1, 1, splashy.inalpha)
-
-			elseif splashy.fadestate == "out" then
-
-				love.graphics.setColor(1, 1, 1, splashy.outalpha)
-
-			end
 
 			-- If the current splash is the one in the list.
 
@@ -94,13 +115,27 @@ function splashy.draw()
 				-- Then grab the splash from the list and draw it to the screen.
 
 				local splash = splashy.list[i]
-				local centerwidth = love.graphics.getWidth() / 2
-				local centerheight = love.graphics.getHeight() / 2
+				local scale = splashy.scaleList[i]
+				local centerwidth = splashy.screenWidth / 2
+				local centerheight = splashy.screenHeight / 2
 
-				local centerimagewidth = splash:getWidth() / 2
-				local centerimageheight = splash:getHeight() / 2
+				local centerimagewidth = (splash:getWidth() * scale) / 2
+				local centerimageheight = (splash:getHeight() * scale) / 2
 
-				love.graphics.draw(splash, centerwidth - centerimagewidth, centerheight - centerimageheight)
+				love.graphics.setColor (splashy.colorList[i])
+				love.graphics.rectangle ("fill", 0, 0, splashy.screenWidth, splashy.screenHeight)
+				
+				if splashy.fadestate == "in" then
+
+					love.graphics.setColor(1, 1, 1, splashy.inalpha)
+
+				elseif splashy.fadestate == "out" then
+
+					love.graphics.setColor(1, 1, 1, splashy.outalpha)
+
+				end
+
+				love.graphics.draw(splash, centerwidth - centerimagewidth, centerheight - centerimageheight, nil, scale, scale)
 
 			end
 
@@ -112,6 +147,8 @@ function splashy.draw()
 
 end
 
+--- Renders Splashy.
+-- This should be placed in love.update (dt)
 function splashy.update(dt)
 
 	if splashy.finished == false then


### PR DESCRIPTION
Background colors: Users can now choose a specific background color for each splash screen

Scaling: Users can scale the image according to their needs. Good for when an image might be too small and the user doesn't want to create a high-res version just for the splash screen

Custom resolution: Users can set the screen resolution that will be used for the internal calculations. This is helpful for projects that use screen scaling libraries like Push or TLfres.

I also added LDoc style comments to the functions and gave "splashy.onCompleteFunction" a default function. I think that makes more sense in my opinion.

Example:
![image](https://github.com/videah/splashy/assets/45105509/41023a98-096c-4c49-a2be-32410c75a8e8)
![image](https://github.com/videah/splashy/assets/45105509/08d677fa-26ca-4c69-9311-ffa83ce28914)
![image](https://github.com/videah/splashy/assets/45105509/e5cbe299-5a36-48ea-8362-aff67b3a3751)
